### PR TITLE
Distinguish between SSL cert and Oauth Resource Server cert. Make…

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,10 +5,10 @@ DEBUG = False
 # The following four variables configure authentication
 
 # If using a public key, set the environment variable AUTH_TOKEN_KEY_URL to the url where it can be retrieved
-AUTH_TOKEN_KEY_URL = os.getenv('oauthResourceTokenKeyUri')
+AUTH_TOKEN_KEY_URL = os.getenv('oauth_server_token_key_url')
 
 # Set the path to the certificate for AUTH_TOKEN_KEY_URL. If set to False then, SSL verification will not occur.
-AUTH_CERT_PATH = os.getenv('ssl_cert_path', True)
+AUTH_CERT_PATH = os.getenv('oauth_server_cert_path', True)
 
 # If using the above, use the AUTH_TOKEN_KEY_ALGORITHM to set the algorithm. By default it will be RS256
 JWT_ALGORITHM = os.getenv('jwt_algorithm', 'HS256')


### PR DESCRIPTION
… variable naming consistent, rather than split between various conventions.

@kmschoep-usgs Figured it would be a bit cleaner to keep the naming convention consistent within the individual applications than across the applications. I'm going to update the python services to use this name instead that way all of the MLR python services are consistent among themselves (though they are different from the Java services, which I think is okay since they use a different docker base image).

Also sorry for not catching the other issue the first time around, didn't realize what cert this was referring to. Looks like in the application the cert at AUTH_CERT_PATH is supposed to be the SSL cert served by the Oauth2 server (i.e Water Auth), rather than the ssl cert served by this service.