### PR TITLE
Updated requests to fix a vulnerability. Added site number length…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,6 @@ ENV/
 
 # ide directories
 .idea
-
+.vscode
 root.crt
 /.project

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ pycparser==2.18
 PyJWT==1.5.3
 python-dateutil==2.6.1
 pytz==2017.2
-requests==2.18.4
+requests==2.20.0
 six==1.10.0
 urllib3==1.22
 Werkzeug==0.12.2


### PR DESCRIPTION
…validation and associated tests. Updated gitignore.

This change prevents an invalid site number from being parsed when a DDot file contains a 16-character site number and no space between the number and the first key-value pair. Previsouly this would result in the first 15 characters of the invalid site number being parsed and the rest of the file parsing successfully, creating the potential for invalid data to be inserted into MLR with the 15-digit trimmed site number.