### PR TITLE
Fixed a bug when DDots are parsed that have lines < 21 characters.

### DIFF
--- a/ddot_utils.py
+++ b/ddot_utils.py
@@ -103,22 +103,27 @@ def validate_lines(lines):
     empty string indicates successful validation.
     """
     too_long_lines = []
+    too_short_lines = []
     bad_site_lines = []
     error_message = ""
     for index, line in enumerate(lines):
         if len(line) > 80:
             too_long_lines.append(index + 2)
-        elif len(line) < 21 or line[20] != ' ':
+        elif len(line) < 21:
+            too_short_lines.append(index + 2)
+        elif line[20] != ' ':
             bad_site_lines.append(index + 2)
 
     if too_long_lines:
         error_message += "Contains lines exceeding 80 characters: lines {0}. ".format(', '.join([str(line) for line in too_long_lines]))
+
+    if too_short_lines:
+        error_message += "Contains lines with an invalid agency code / site number format (fewer than 21 characters): lines {0}. ".format(', '.join([str(line) for line in too_short_lines]))
     
     if bad_site_lines:
-        error_message += "Contains lines with invalid site number format: lines {0}.".format(', '.join([str(line) for line in bad_site_lines]))
+        error_message += "Contains lines with invalid site number format: lines {0}. ".format(', '.join([str(line) for line in bad_site_lines]))
         
     return error_message
-
 
 def get_transactions(lines):
     """

--- a/ddot_utils.py
+++ b/ddot_utils.py
@@ -99,7 +99,7 @@ def validate_lines(lines):
     :param list of str lines:
     :rtype: list of dicts for each location in content
     :return: Returns a string containing any validation errors (lines with 
-    length > 80 or with invalid site numbres - no space in position 21). An
+    length > 80 or with invalid site numbers - no space in position 21). An
     empty string indicates successful validation.
     """
     too_long_lines = []
@@ -108,7 +108,7 @@ def validate_lines(lines):
     for index, line in enumerate(lines):
         if len(line) > 80:
             too_long_lines.append(index + 2)
-        elif line[20] != ' ':
+        elif len(line) < 21 or line[20] != ' ':
             bad_site_lines.append(index + 2)
 
     if too_long_lines:

--- a/ddot_utils.py
+++ b/ddot_utils.py
@@ -99,8 +99,8 @@ def validate_lines(lines):
     :param list of str lines:
     :rtype: list of dicts for each location in content
     :return: Returns a string containing any validation errors (lines with 
-    length > 80 or with invalid site numbers - no space in position 21). An
-    empty string indicates successful validation.
+    length > 80, with length < 21, and with invalid site numbers - no space 
+    in position 21). An empty string indicates successful validation.
     """
     too_long_lines = []
     too_short_lines = []

--- a/tests/test_ddot_utils.py
+++ b/tests/test_ddot_utils.py
@@ -123,7 +123,8 @@ class ValidateLinesTestCase(TestCase):
             'USGS 4800421084333012R=0* T=A* 12=\'YELLVILLE WATERWORKS\'* 11=S* 35=M* 36=NAD27*',
             'USGS 48004210843330 R=0* T=A* 12=\'YELLVILLE WATERWORKS\'* 11=S* 35=M* 36=NAD27*',
             'USGS 480042108433301 39=WS* 813=CST* 814=Y* 3=C* 41=US*',
-            'USGS 480042108433301 R=0* T=A* 12=\'YELLVILLE WATERWORKS JUNK JUNK JUNK JUNK STUFF STUFF STUFF STUFF\'* 11=S* 35=M* 36=NAD27*'
+            'USGS 480042108433301 R=0* T=A* 12=\'YELLVILLE WATERWORKS JUNK JUNK JUNK JUNK STUFF STUFF STUFF STUFF\'* 11=S* 35=M* 36=NAD27*',
+            'USGS 48 R=0*'
         ]
 
     def test_with_valid_lines(self):
@@ -136,19 +137,19 @@ class ValidateLinesTestCase(TestCase):
 
     def test_with_invalid_site_number_long(self):
         result = validate_lines(self.invalid_site_number_long)
-        self.assertEqual(result, "Contains lines with invalid site number format: lines 2, 3, 4.")
+        self.assertEqual(result, "Contains lines with invalid site number format: lines 2, 3, 4. ")
 
     def test_with_invalid_site_number_short(self):
         result = validate_lines(self.invalid_site_number_short)
-        self.assertEqual(result, "Contains lines with invalid site number format: lines 2, 3, 4.")
+        self.assertEqual(result, "Contains lines with invalid site number format: lines 2, 3, 4. ")
     
     def test_with_invalid_site_number_very_short(self):
         result = validate_lines(self.invalid_site_number_very_short)
-        self.assertEqual(result, "Contains lines with invalid site number format: lines 2, 3, 4.")
+        self.assertEqual(result, "Contains lines with an invalid agency code / site number format (fewer than 21 characters): lines 2, 3, 4. ")
 
     def test_with_multi_error(self):
         result = validate_lines(self.multi_errors)
-        self.assertEqual(result, "Contains lines exceeding 80 characters: lines 5. Contains lines with invalid site number format: lines 2, 3.")
+        self.assertEqual(result, "Contains lines exceeding 80 characters: lines 5. Contains lines with an invalid agency code / site number format (fewer than 21 characters): lines 6. Contains lines with invalid site number format: lines 2, 3. ")
     
 class ParseTestCase(TestCase):
 

--- a/tests/test_ddot_utils.py
+++ b/tests/test_ddot_utils.py
@@ -113,6 +113,12 @@ class ValidateLinesTestCase(TestCase):
             'USGS 48004210843331 39=WS* 813=CST* 814=Y* 3=C* 41=US*'
         ]
 
+        self.invalid_site_number_very_short = [
+            'USGS 48 R=0*',
+            'USGS 48 6=05*',
+            'USGS 48 39=WS*'
+        ]
+
         self.multi_errors = [
             'USGS 4800421084333012R=0* T=A* 12=\'YELLVILLE WATERWORKS\'* 11=S* 35=M* 36=NAD27*',
             'USGS 48004210843330 R=0* T=A* 12=\'YELLVILLE WATERWORKS\'* 11=S* 35=M* 36=NAD27*',
@@ -134,6 +140,10 @@ class ValidateLinesTestCase(TestCase):
 
     def test_with_invalid_site_number_short(self):
         result = validate_lines(self.invalid_site_number_short)
+        self.assertEqual(result, "Contains lines with invalid site number format: lines 2, 3, 4.")
+    
+    def test_with_invalid_site_number_very_short(self):
+        result = validate_lines(self.invalid_site_number_very_short)
         self.assertEqual(result, "Contains lines with invalid site number format: lines 2, 3, 4.")
 
     def test_with_multi_error(self):
@@ -190,6 +200,11 @@ class ParseTestCase(TestCase):
             'USGS 48004210843331 39=WS* 813=CST* 814=Y* 3=C* 41=US*'
         )
 
+        self.invalid_site_number_very_short = (
+            'USGS 48 R=0*\r\n'
+            'USGS 48 6=05*\r\n'
+            'USGS 48 39=WS*\r\n'
+        )
 
     def test_no_contents(self):
         with self.assertRaises(ParseError):
@@ -213,8 +228,12 @@ class ParseTestCase(TestCase):
         with self.assertRaises(ParseError) as e:
             parse('XXXXXXX\n' + self.invalid_site_number_short)
         self.assertIn('lines 2, 3, 4', e.exception.message)
-    
 
+    def test_with_invalid_site_number_very_short(self):
+        with self.assertRaises(ParseError) as e:
+            parse('XXXXXXX\n' + self.invalid_site_number_very_short)
+        self.assertIn('lines 2, 3, 4', e.exception.message)
+    
     def test_with_single_location(self):
         result = parse('XXXXXXX\n' +self.location1)
         self.assertEqual(len(result), 1)


### PR DESCRIPTION
Found this while trying to produce a bunch of different errors for my current task.