### PR TITLE
Standardizing Error Messages

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,6 @@
 import os
 import requests
 
-
 from flask import Flask
 
 application = Flask(__name__)

--- a/config.py
+++ b/config.py
@@ -16,6 +16,7 @@ JWT_ALGORITHM = os.getenv('jwt_algorithm', 'HS256')
 # Set the JWT_DECODE_AUDIENCE environment variable to the value of the 'aud' claim in the
 JWT_DECODE_AUDIENCE = os.getenv('jwt_decode_audience')
 
+ERROR_INCLUDE_MESSAGE=False
 
 
 

--- a/config.py
+++ b/config.py
@@ -16,5 +16,5 @@ JWT_ALGORITHM = os.getenv('jwt_algorithm', 'HS256')
 # Set the JWT_DECODE_AUDIENCE environment variable to the value of the 'aud' claim in the
 JWT_DECODE_AUDIENCE = os.getenv('jwt_decode_audience')
 
-# Configure exceptions to not alawuys output with a `message` field. Global exception handling is done via a custom handler in services.py.
+# Configure exception JSON to not always output with a `message` field. Global exception handling is done via a custom handler in services.py.
 ERROR_INCLUDE_MESSAGE=False

--- a/config.py
+++ b/config.py
@@ -16,7 +16,5 @@ JWT_ALGORITHM = os.getenv('jwt_algorithm', 'HS256')
 # Set the JWT_DECODE_AUDIENCE environment variable to the value of the 'aud' claim in the
 JWT_DECODE_AUDIENCE = os.getenv('jwt_decode_audience')
 
+# Configure exceptions to not alawuys output with a `message` field. Global exception handling is done via a custom handler in services.py.
 ERROR_INCLUDE_MESSAGE=False
-
-
-

--- a/flask_restplus_jwt.py
+++ b/flask_restplus_jwt.py
@@ -2,10 +2,8 @@ from functools import wraps
 
 from flask import current_app, jsonify
 from flask_jwt_simple import JWTManager, jwt_required as simple_jwt_required, get_jwt
-from flask_jwt_simple.exceptions import NoAuthorizationError, InvalidHeaderError
-
-from jwt.exceptions import ExpiredSignatureError, DecodeError, InvalidAudienceError
-
+from flask_jwt_simple.exceptions import NoAuthorizationError
+from jwt.exceptions import InvalidTokenError
 
 
 class JWTRestplusManager(JWTManager):
@@ -26,10 +24,19 @@ class JWTRestplusManager(JWTManager):
         # https://github.com/vimalloc/flask-jwt-extended/issues/86
         self._set_error_handler_callbacks(api)
 
-        # Override default error handlers
+        # As a result of https://github.com/noirbizarre/flask-restplus/issues/421 we must register
+        # the invalid token error handler for each sub-class of jwt.exceptions.InvalidTokenError
+        def handle_invalid_token_error(e):
+            return self._invalid_token_callback(str(e))
+
+        for subclass in InvalidTokenError.__subclasses__():
+            (api.errorhandler(subclass))(handle_invalid_token_error)
+
+        # Override default error callbacks
         self.expired_token_loader(expired_token_callback)
         self.invalid_token_loader(invalid_token_callback)
         self.unauthorized_loader(unauthorized_callback)
+
 
 # Slightly tweaked version of the default callback from flask_jwt_simple.default_callbacks
 def expired_token_callback():

--- a/flask_restplus_jwt.py
+++ b/flask_restplus_jwt.py
@@ -31,15 +31,15 @@ class JWTRestplusManager(JWTManager):
         self.invalid_token_loader(invalid_token_callback)
         self.unauthorized_loader(unauthorized_callback)
 
-
+# Slightly tweaked version of the default callback from flask_jwt_simple.default_callbacks
 def expired_token_callback():
     return jsonify({'error_message': 'Token has expired'}), 401
 
-
+# Slightly tweaked version of the default callback from flask_jwt_simple.default_callbacks
 def invalid_token_callback(error_string):
     return jsonify({'error_message': error_string}), 422
 
-
+# Slightly tweaked version of the default callback from flask_jwt_simple.default_callbacks
 def unauthorized_callback(error_string):
     return jsonify({'error_message': error_string}), 401
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ click==6.7
 cryptography>=2.3
 Flask==0.12.3
 Flask-JWT-Simple==0.0.3
-flask-restplus==0.10.1
+flask-restplus==0.12.1
 idna==2.6
 itsdangerous==0.24
 Jinja2==2.9.6

--- a/services.py
+++ b/services.py
@@ -99,7 +99,8 @@ class DdotIngester(Resource):
     @api.response(200, 'Successfully uploaded and parsed', [location_transaction_model])
     @api.response(400, 'File can not be parsed', error_model)
     @api.response(500, 'File parsing failed.', error_model)
-    @api.response(401, 'Not authorized')
+    @api.response(401, 'Not authorized or token expired', error_model)
+    @api.response(422, 'Invalid JWT Token', error_model)
     @api.doc(security='apikey')
     @api.expect(parser)
     @jwt_required
@@ -151,3 +152,8 @@ class Version(Resource):
                 "artifact": distribution.project_name
             }
         return resp
+
+@api.errorhandler
+def default_error_handler(error):
+    '''Default error handler'''
+    return {'error_message': str(error)}, getattr(error, 'code', 500)

--- a/services.py
+++ b/services.py
@@ -98,6 +98,7 @@ class DdotIngester(Resource):
 
     @api.response(200, 'Successfully uploaded and parsed', [location_transaction_model])
     @api.response(400, 'File can not be parsed', error_model)
+    @api.response(500, 'File parsing failed.', error_model)
     @api.response(401, 'Not authorized')
     @api.doc(security='apikey')
     @api.expect(parser)
@@ -112,6 +113,14 @@ class DdotIngester(Resource):
             response, status = {
                 'error_message': err.message
             }, 400
+        except UnicodeDecodeError as err:
+            response, status = {
+                'error_message': 'Uploaded file cannot be read (not encoded as UTF-8).'
+            }, 400
+        except:
+            response, status = {
+                'error_message': 'An unexpected error occured while parsing the submitted file.'
+            }, 500
         else:
             response, status = result, 200
 


### PR DESCRIPTION
Changes:

Previously error messages came in several formats:

```
{"msg": "<message>"} --> For JWT/Auth exceptions
{"message": "<message>"} --> For uncaught exceptions
{"error_message": "<message>"} --> For caught exceptions
```

This PR standardizes all of the above cases to the `{"error_message": "<message>"}` format.